### PR TITLE
Implement single post fetching endpoint

### DIFF
--- a/API/handlers/post_handler.go
+++ b/API/handlers/post_handler.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"forum/middleware"
 	"forum/models"
@@ -12,12 +14,18 @@ import (
 
 // PostHandler handles post related endpoints
 type PostHandler struct {
-	PostRepo *repository.PostRepository
+	PostRepo     *repository.PostRepository
+	CommentRepo  *repository.CommentRepository
+	ReactionRepo *repository.ReactionRepository
 }
 
 // NewPostHandler creates a new PostHandler
-func NewPostHandler(repo *repository.PostRepository) *PostHandler {
-	return &PostHandler{PostRepo: repo}
+func NewPostHandler(postRepo *repository.PostRepository, commentRepo *repository.CommentRepository, reactionRepo *repository.ReactionRepository) *PostHandler {
+	return &PostHandler{
+		PostRepo:     postRepo,
+		CommentRepo:  commentRepo,
+		ReactionRepo: reactionRepo,
+	}
 }
 
 // CreatePost creates a new post for the authenticated user
@@ -34,24 +42,24 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-    CategoryIDs []int  `json:"category_ids"` // Instead of CategoryID
-    Title       string `json:"title"`
-    Content     string `json:"content"`
-}
+		CategoryIDs []int  `json:"category_ids"` // Instead of CategoryID
+		Title       string `json:"title"`
+		Content     string `json:"content"`
+	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		utils.ErrorResponse(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 	if len(req.CategoryIDs) == 0 || req.Title == "" || req.Content == "" {
-    utils.ErrorResponse(w, "At least one category, title and content are required", http.StatusBadRequest)
-    return
-}
+		utils.ErrorResponse(w, "At least one category, title and content are required", http.StatusBadRequest)
+		return
+	}
 
 	post := models.Post{
-		UserID:     user.ID,
-		Title:      req.Title,
-		Content:    req.Content,
+		UserID:  user.ID,
+		Title:   req.Title,
+		Content: req.Content,
 	}
 
 	created, err := h.PostRepo.Create(post, req.CategoryIDs)
@@ -61,4 +69,97 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.JSONResponse(w, created, http.StatusCreated)
+}
+
+// GetPost loads a single post with all related data
+func (h *PostHandler) GetPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/forum/api/posts/")
+	if id == "" {
+		utils.ErrorResponse(w, "Post ID required", http.StatusBadRequest)
+		return
+	}
+
+	post, err := h.PostRepo.GetPostByIDWithUser(id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			utils.ErrorResponse(w, "Post not found", http.StatusNotFound)
+			return
+		}
+		utils.ErrorResponse(w, "Failed to load post", http.StatusInternalServerError)
+		return
+	}
+
+	categories, err := h.PostRepo.GetCategoriesByPostID(post.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load categories", http.StatusInternalServerError)
+		return
+	}
+	var catInfo []CategoryInfo
+	for _, c := range categories {
+		catInfo = append(catInfo, CategoryInfo{ID: c.ID, Name: c.Name})
+	}
+
+	comments, err := h.CommentRepo.GetCommentsByPostWithUser(post.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load comments", http.StatusInternalServerError)
+		return
+	}
+	var commentResp []CommentResponse
+	for _, c := range comments {
+		cr := CommentResponse{
+			ID:        c.ID,
+			UserID:    c.UserID,
+			Username:  c.Username,
+			Content:   c.Content,
+			CreatedAt: c.CreatedAt,
+			Reactions: []ReactionResponse{},
+		}
+		reactions, err := h.ReactionRepo.GetReactionsByCommentWithUser(c.ID)
+		if err != nil {
+			utils.ErrorResponse(w, "Failed to load reactions", http.StatusInternalServerError)
+			return
+		}
+		for _, r := range reactions {
+			cr.Reactions = append(cr.Reactions, ReactionResponse{
+				UserID:       r.UserID,
+				Username:     r.Username,
+				ReactionType: r.ReactionType,
+				CreatedAt:    r.CreatedAt,
+			})
+		}
+		commentResp = append(commentResp, cr)
+	}
+
+	reactions, err := h.ReactionRepo.GetReactionsByPostWithUser(post.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load reactions", http.StatusInternalServerError)
+		return
+	}
+	var reactResp []ReactionResponse
+	for _, r := range reactions {
+		reactResp = append(reactResp, ReactionResponse{
+			UserID:       r.UserID,
+			Username:     r.Username,
+			ReactionType: r.ReactionType,
+			CreatedAt:    r.CreatedAt,
+		})
+	}
+
+	resp := MyPostResponse{
+		ID:         post.ID,
+		UserID:     post.UserID,
+		Username:   post.Username,
+		Categories: catInfo,
+		Title:      post.Title,
+		Content:    post.Content,
+		CreatedAt:  post.CreatedAt,
+		Comments:   commentResp,
+		Reactions:  reactResp,
+	}
+	utils.JSONResponse(w, resp, http.StatusOK)
 }

--- a/API/repository/post_repository.go
+++ b/API/repository/post_repository.go
@@ -190,3 +190,18 @@ func (r *PostRepository) GetPostsReactedByUser(userID string) ([]models.PostWith
 	}
 	return posts, nil
 }
+func (r *PostRepository) GetPostByIDWithUser(postID string) (*models.PostWithUser, error) {
+	row := r.db.QueryRow(`
+                SELECT p.post_id, p.user_id, u.username, p.title, p.content, p.created_at
+                FROM posts p
+                JOIN user u ON p.user_id = u.user_id
+                WHERE p.post_id = ?`, postID)
+	var p models.PostWithUser
+	if err := row.Scan(&p.ID, &p.UserID, &p.Username, &p.Title, &p.Content, &p.CreatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, err
+		}
+		return nil, err
+	}
+	return &p, nil
+}

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -22,7 +22,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	// Create handlers
 	authHandler := handlers.NewAuthHandler(userRepo, sessionRepo)
 	categoryHandler := handlers.NewCategoryHandler(categoryRepo)
-	postHandler := handlers.NewPostHandler(postRepo)
+	postHandler := handlers.NewPostHandler(postRepo, commentRepo, reactionRepo)
 	myPostsHandler := handlers.NewMyPostsHandler(postRepo, commentRepo, reactionRepo)
 	likedPostsHandler := handlers.NewLikedPostsHandler(postRepo, commentRepo, reactionRepo)
 	commentHandler := handlers.NewCommentHandler(commentRepo)
@@ -41,6 +41,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	// Public routes
 	mux.Handle("/forum/api/categories", corsMiddleware.Handler(http.HandlerFunc(categoryHandler.GetCategories)))
 	mux.Handle("/forum/api/allData", corsMiddleware.Handler(http.HandlerFunc(guestHandler.GetGuestData)))
+	mux.Handle("/forum/api/posts/", corsMiddleware.Handler(http.HandlerFunc(postHandler.GetPost)))
 	mux.Handle("/forum/api/register", corsMiddleware.Handler(http.HandlerFunc(registerLimiter.Limit(authHandler.Register))))
 	mux.Handle("/forum/api/session/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.Login)))
 	mux.Handle("/forum/api/session/logout", corsMiddleware.Handler(http.HandlerFunc(authHandler.Logout)))

--- a/ui/cmd/main.go
+++ b/ui/cmd/main.go
@@ -19,6 +19,7 @@ var (
 	CreatePostURI = APIBaseURL + "/posts/create"
 	MyPostsURI    = APIBaseURL + "/user/posts"
 	LikedPostsURI = APIBaseURL + "/user/liked"
+	PostURI       = APIBaseURL + "/posts/"
 )
 
 func main() {
@@ -36,16 +37,16 @@ func main() {
 	http.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/register.html")
 	})
-        http.HandleFunc("/guest", func(w http.ResponseWriter, r *http.Request) {
-                http.ServeFile(w, r, "./static/templates/guest.html")
-        })
-        http.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-                http.ServeFile(w, r, "./static/templates/user.html")
-        })
-        http.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
-                http.ServeFile(w, r, "./static/templates/post.html")
-        })
-        http.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/guest", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./static/templates/guest.html")
+	})
+	http.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./static/templates/user.html")
+	})
+	http.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./static/templates/post.html")
+	})
+	http.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		config := map[string]string{
 			"APIBaseURL":    APIBaseURL,
@@ -60,6 +61,7 @@ func main() {
 			"CreatePostURI": CreatePostURI,
 			"MyPostsURI":    MyPostsURI,
 			"LikedPostsURI": LikedPostsURI,
+			"PostURI":       PostURI,
 		}
 		json.NewEncoder(w).Encode(config)
 	})

--- a/ui/static/js/user-post-page.js
+++ b/ui/static/js/user-post-page.js
@@ -28,11 +28,6 @@ import { ForumRenderer } from "./user-forum-renderer.js";
     const forumRenderer = new ForumRenderer(postRenderer, dataManager);
 
     const API_CONFIG = configManager.getConfig();
-    const res = await fetch(API_CONFIG.DataURI);
-    if (!res.ok) throw new Error("Failed to fetch post data");
-    const guestData = await res.json();
-    dataManager.setData(guestData);
-
     const params = new URLSearchParams(window.location.search);
     const postId = params.get("id");
     if (!postId) {
@@ -40,6 +35,30 @@ import { ForumRenderer } from "./user-forum-renderer.js";
       return;
     }
 
+    const res = await fetch(API_CONFIG.PostURI + postId);
+    if (!res.ok) throw new Error("Failed to fetch post data");
+    const post = await res.json();
+
+    const data = {
+      categories: post.categories.map((c) => ({
+        id: c.id,
+        name: c.name,
+        posts: [
+          {
+            id: post.id,
+            user_id: post.user_id,
+            username: post.username,
+            title: post.title,
+            content: post.content,
+            created_at: post.created_at,
+            comments: post.comments,
+            reactions: post.reactions,
+          },
+        ],
+      })),
+    };
+
+    dataManager.setData(data);
     forumRenderer.renderSinglePost(postId);
   } catch (err) {
     console.error("Error loading post:", err);


### PR DESCRIPTION
## Summary
- allow retrieving one post by ID for guests and authenticated users
- expand PostHandler to gather full post details
- wire up new GET `/forum/api/posts/{id}` route
- expose single post URL to frontend and load posts per ID

## Testing
- `go vet ./...` *(fails: unable to download Go toolchain)*
- `go build ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6853e8d124908324a48a07a23a353c32