### PR TITLE
Add minimal JS frontend for posts

### DIFF
--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('forumContainer');
+  const catTpl = document.getElementById('category-template');
+  const postTpl = document.getElementById('post-template');
+  const commentTpl = document.getElementById('comment-template');
+  try {
+    const res = await fetch('http://localhost:8080/forum/api/allData');
+    if (!res.ok) throw new Error('failed to load');
+    const data = await res.json();
+    container.innerHTML = '';
+    for (const cat of data.categories) {
+      const catEl = catTpl.content.cloneNode(true);
+      catEl.querySelector('.category-title').textContent = cat.name;
+      const postsCont = catEl.querySelector('.category-posts');
+      for (const post of cat.posts) {
+        const postEl = postTpl.content.cloneNode(true);
+        postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+        postEl.querySelector('.post-title').textContent = post.title;
+        postEl.querySelector('.post-content').textContent = post.content;
+        postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();
+        const commentsCont = postEl.querySelector('.post-comments');
+        for (const comment of post.comments || []) {
+          const cEl = commentTpl.content.cloneNode(true);
+          cEl.querySelector('.comment-user').textContent = comment.username;
+          cEl.querySelector('.comment-content').textContent = comment.content;
+          cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
+          commentsCont.appendChild(cEl);
+        }
+        postsCont.appendChild(postEl);
+      }
+      container.appendChild(catEl);
+    }
+  } catch (err) {
+    container.textContent = 'Error loading posts';
+  }
+});

--- a/ui/static/js/login.js
+++ b/ui/static/js/login.js
@@ -1,0 +1,23 @@
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value.trim();
+  const message = document.getElementById('message');
+  message.textContent = '';
+  try {
+    const res = await fetch('http://localhost:8080/forum/api/session/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.message || 'Login failed');
+    if (data.csrf_token) {
+      sessionStorage.setItem('csrf_token', data.csrf_token);
+    }
+    window.location.href = '/user';
+  } catch (err) {
+    message.textContent = err.message;
+  }
+});

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -1,0 +1,149 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('forumContainer');
+  const catTpl = document.getElementById('category-template');
+  const postTpl = document.getElementById('post-template');
+  const commentTpl = document.getElementById('comment-template');
+  const csrfToken = sessionStorage.getItem('csrf_token');
+  async function verify() {
+    const res = await fetch('http://localhost:8080/forum/api/session/verify', {credentials:'include'});
+    return res.ok;
+  }
+  if (!(await verify())) {
+    window.location.href = '/login';
+    return;
+  }
+  const logoutLink = document.getElementById('logout-link');
+  if (logoutLink) {
+    logoutLink.addEventListener('click', async (e) => {
+      e.preventDefault();
+      await fetch('http://localhost:8080/forum/api/session/logout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-CSRF-Token': csrfToken }
+      });
+      window.location.href = '/';
+    });
+  }
+  async function loadData() {
+    const res = await fetch('http://localhost:8080/forum/api/allData', {credentials:'include'});
+    if (!res.ok) throw new Error('load error');
+    const data = await res.json();
+    renderData(data);
+  }
+  function renderData(data) {
+    container.innerHTML = '';
+    for (const cat of data.categories) {
+      const catEl = catTpl.content.cloneNode(true);
+      catEl.querySelector('.category-title').textContent = cat.name;
+      const postsCont = catEl.querySelector('.category-posts');
+      for (const post of cat.posts) {
+        const postEl = postTpl.content.cloneNode(true);
+        postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+        postEl.querySelector('.post-title').textContent = post.title;
+        postEl.querySelector('.post-content').textContent = post.content;
+        postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();
+        const likeBtn = postEl.querySelector('.like-btn');
+        const dislikeBtn = postEl.querySelector('.dislike-btn');
+        const likes = (post.reactions || []).filter(r => r.reaction_type === 1).length;
+        const dislikes = (post.reactions || []).filter(r => r.reaction_type === 2).length;
+        likeBtn.querySelector('.like-count').textContent = likes;
+        dislikeBtn.querySelector('.dislike-count').textContent = dislikes;
+        likeBtn.addEventListener('click', () => react(post.id, 'post', 1));
+        dislikeBtn.addEventListener('click', () => react(post.id, 'post', 2));
+        const commentsCont = postEl.querySelector('.post-comments');
+        for (const comment of post.comments || []) {
+          const cEl = commentTpl.content.cloneNode(true);
+          cEl.querySelector('.comment-user').textContent = comment.username;
+          cEl.querySelector('.comment-content').textContent = comment.content;
+          cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
+          commentsCont.appendChild(cEl);
+        }
+        const commentBtn = postEl.querySelector('.comment-btn');
+        commentBtn.addEventListener('click', async () => {
+          const text = prompt('Comment:');
+          if (text) {
+            await createComment(post.id, text);
+            await loadData();
+          }
+        });
+        postsCont.appendChild(postEl);
+      }
+      container.appendChild(catEl);
+    }
+  }
+  async function react(id, type, rtype) {
+    await fetch('http://localhost:8080/forum/api/react', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken
+      },
+      body: JSON.stringify({ target_id: id, target_type: type, reaction_type: rtype })
+    });
+    loadData();
+  }
+  async function createComment(postId, content) {
+    await fetch('http://localhost:8080/forum/api/comments', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken
+      },
+      body: JSON.stringify({ post_id: postId, content })
+    });
+  }
+  const createBtn = document.getElementById('create-post-btn');
+  const modal = document.getElementById('post-modal');
+  const closeBtn = document.querySelector('.close-btn');
+  const submitBtn = document.getElementById('submit-post');
+  if (createBtn) {
+    createBtn.addEventListener('click', () => modal.classList.remove('hidden'));
+  }
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
+  }
+  if (submitBtn) {
+    submitBtn.addEventListener('click', createPost);
+  }
+  async function loadCategories() {
+    const res = await fetch('http://localhost:8080/forum/api/categories');
+    if (!res.ok) return;
+    const cats = await res.json();
+    const cont = document.getElementById('post-category');
+    cont.innerHTML = '';
+    cats.forEach(c => {
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.value = c.id;
+      const label = document.createElement('label');
+      label.textContent = c.name;
+      const wrap = document.createElement('div');
+      wrap.className = 'checkbox-item';
+      wrap.appendChild(cb);
+      wrap.appendChild(label);
+      cont.appendChild(wrap);
+    });
+  }
+  async function createPost() {
+    const title = document.getElementById('post-title').value.trim();
+    const content = document.getElementById('post-body').value.trim();
+    const catChecks = document.querySelectorAll('#post-category input:checked');
+    const ids = Array.from(catChecks).map(c => parseInt(c.value,10));
+    if (!title || !content || ids.length === 0) return;
+    await fetch('http://localhost:8080/forum/api/posts/create', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken
+      },
+      body: JSON.stringify({ title, content, category_ids: ids })
+    });
+    modal.classList.add('hidden');
+    await loadData();
+  }
+  loadCategories();
+  loadData();
+});

--- a/ui/static/templates/guest.html
+++ b/ui/static/templates/guest.html
@@ -68,5 +68,6 @@
         </div>
       </div>
     </template>
+    <script type="module" src="/static/js/guest.js"></script>
   </body>
 </html>

--- a/ui/static/templates/login.html
+++ b/ui/static/templates/login.html
@@ -66,5 +66,6 @@
         </form>
       </div>
     </div>
-</body>
+    <script type="module" src="/static/js/login.js"></script>
+  </body>
 </html>

--- a/ui/static/templates/user.html
+++ b/ui/static/templates/user.html
@@ -79,5 +79,6 @@
         <button id="submit-post">Submit</button>
       </div>
     </div>
+    <script type="module" src="/static/js/user.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add simple JS for login form and data rendering
- display guest feed with new script
- enhance user view with reactions, comments and post creation

## Testing
- `gofmt -w $(find . -name '*.go') && go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68550994c2c08324832a95b4a87358ee