### PR TITLE
Add custom error API and fetch it in UI

### DIFF
--- a/API/handlers/error_handler.go
+++ b/API/handlers/error_handler.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"forum/utils"
+)
+
+// ErrorHandler returns a JSON error response based on query parameters
+func ErrorHandler(w http.ResponseWriter, r *http.Request) {
+	codeStr := r.URL.Query().Get("code")
+	code, _ := strconv.Atoi(codeStr)
+	if code == 0 {
+		code = http.StatusInternalServerError
+	}
+
+	msg := r.URL.Query().Get("message")
+	if msg == "" {
+		msg = http.StatusText(code)
+	}
+
+	utils.ErrorResponse(w, msg, code)
+}

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -28,6 +28,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	commentHandler := handlers.NewCommentHandler(commentRepo)
 	reactionHandler := handlers.NewReactionHandler(reactionRepo)
 	guestHandler := handlers.NewGuestHandler(categoryRepo, postRepo, commentRepo, reactionRepo)
+	// error handler doesn't need dependencies
 
 	// Create middleware
 	registerLimiter := middleware.NewRateLimiter()
@@ -46,6 +47,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	mux.Handle("/forum/api/session/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.Login)))
 	mux.Handle("/forum/api/session/logout", corsMiddleware.Handler(http.HandlerFunc(authHandler.Logout)))
 	mux.Handle("/forum/api/session/verify", corsMiddleware.Handler(http.HandlerFunc(authHandler.VerifySession)))
+	mux.Handle("/forum/api/error", corsMiddleware.Handler(http.HandlerFunc(handlers.ErrorHandler)))
 
 	// Protected routes with CSRF
 	protected := func(h http.Handler) http.Handler {

--- a/ui/cmd/main.go
+++ b/ui/cmd/main.go
@@ -3,36 +3,66 @@ package main
 import (
 	"log"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
+func renderError(w http.ResponseWriter, r *http.Request, code int, msg string) {
+	q := url.Values{}
+	q.Set("code", strconv.Itoa(code))
+	q.Set("message", msg)
+	r.URL.RawQuery = q.Encode()
+	w.WriteHeader(code)
+	http.ServeFile(w, r, "./static/templates/error.html")
+}
+
 func main() {
+	mux := http.NewServeMux()
+
 	// Serve static assets (css, js, images)
 	fs := http.FileServer(http.Dir("./static"))
-	http.Handle("/static/", http.StripPrefix("/static/", fs))
+	mux.Handle("/static/", http.StripPrefix("/static/", fs))
 
 	// Serve individual HTML pages
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			renderError(w, r, http.StatusNotFound, "Page not found")
+			return
+		}
 		http.ServeFile(w, r, "./static/templates/index.html")
 	})
-	http.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/login.html")
 	})
-	http.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/register.html")
 	})
-	http.HandleFunc("/guest", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/guest", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/guest.html")
 	})
-	http.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/user.html")
 	})
-	http.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/post.html")
+	})
+
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		codeStr := r.URL.Query().Get("code")
+		code, _ := strconv.Atoi(codeStr)
+		if code == 0 {
+			code = http.StatusInternalServerError
+		}
+		msg := r.URL.Query().Get("message")
+		if msg == "" {
+			msg = http.StatusText(code)
+		}
+		renderError(w, r, code, msg)
 	})
 
 	// Start the server
 	log.Println("Serving on http://localhost:8081/")
-	if err := http.ListenAndServe(":8081", nil); err != nil {
+	if err := http.ListenAndServe(":8081", mux); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/ui/static/templates/error.html
+++ b/ui/static/templates/error.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <style>
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            font-family: 'Open Sans', sans-serif;
+            text-align: center;
+        }
+        .error-container {
+            background: var(--bg-secondary);
+            padding: 2rem 3rem;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+        }
+        .error-code {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+            background-image: var(--gradient-main);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .error-message {
+            margin-bottom: 2rem;
+            color: var(--text-secondary);
+        }
+        .btn {
+            text-decoration: none;
+            padding: 0.8rem 1.5rem;
+            font-size: 1rem;
+            border-radius: 6px;
+            background-image: var(--gradient-main);
+            color: var(--text-primary);
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-code" id="code"></div>
+        <p class="error-message" id="message"></p>
+        <a href="/" class="btn">Go Home</a>
+    </div>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        fetch('http://localhost:8080/forum/api/error?' + params.toString())
+            .then(res => res.json())
+            .then(data => {
+                document.getElementById('code').textContent = data.code;
+                document.getElementById('message').textContent = data.message;
+            })
+            .catch(() => {
+                document.getElementById('code').textContent = params.get('code') || 'Error';
+                document.getElementById('message').textContent = params.get('message') || 'Something went wrong';
+            });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `/forum/api/error` endpoint that returns JSON
- fetch error info from the API in `error.html`

## Testing
- `gofmt -w API/handlers/error_handler.go API/routes/routes.go ui/cmd/main.go`

------
https://chatgpt.com/codex/tasks/task_e_685516093828832482bd767f067982c9