### PR TITLE
Implement guest post page and filtering

### DIFF
--- a/ui/cmd/main.go
+++ b/ui/cmd/main.go
@@ -48,6 +48,9 @@ func main() {
 	mux.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/post.html")
 	})
+	mux.HandleFunc("/post-guest", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./static/templates/post_guest.html")
+	})
 
 	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
 		codeStr := r.URL.Query().Get("code")

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -3,34 +3,94 @@ document.addEventListener('DOMContentLoaded', async () => {
   const catTpl = document.getElementById('category-template');
   const postTpl = document.getElementById('post-template');
   const commentTpl = document.getElementById('comment-template');
+  const tabs = document.getElementById('category-tabs');
+  const feedLink = document.getElementById('my-feed-link');
+  let allData;
+
+  feedLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    renderFeed();
+  });
+
   try {
     const res = await fetch('http://localhost:8080/forum/api/allData');
     if (!res.ok) throw new Error('failed to load');
-    const data = await res.json();
-    container.innerHTML = '';
-    for (const cat of data.categories) {
-      const catEl = catTpl.content.cloneNode(true);
-      catEl.querySelector('.category-title').textContent = cat.name;
-      const postsCont = catEl.querySelector('.category-posts');
-      for (const post of cat.posts) {
-        const postEl = postTpl.content.cloneNode(true);
-        postEl.querySelector('.post-header').textContent = `${post.username} posted`;
-        postEl.querySelector('.post-title').textContent = post.title;
-        postEl.querySelector('.post-content').textContent = post.content;
-        postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();
-        const commentsCont = postEl.querySelector('.post-comments');
-        for (const comment of post.comments || []) {
-          const cEl = commentTpl.content.cloneNode(true);
-          cEl.querySelector('.comment-user').textContent = comment.username;
-          cEl.querySelector('.comment-content').textContent = comment.content;
-          cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
-          commentsCont.appendChild(cEl);
-        }
-        postsCont.appendChild(postEl);
-      }
-      container.appendChild(catEl);
-    }
+    allData = await res.json();
+    populateCategories();
+    renderFeed();
   } catch (err) {
     container.textContent = 'Error loading posts';
+  }
+
+  function populateCategories() {
+    if (!tabs) return;
+    tabs.innerHTML = '';
+    allData.categories.forEach((cat) => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = '#';
+      a.textContent = cat.name;
+      a.dataset.catId = cat.id;
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        renderCategory(cat.id);
+      });
+      li.appendChild(a);
+      tabs.appendChild(li);
+    });
+  }
+
+  function renderFeed() {
+    container.innerHTML = '';
+    allData.categories.forEach(renderCategorySection);
+  }
+
+  function renderCategory(id) {
+    container.innerHTML = '';
+    const cat = allData.categories.find((c) => c.id === id);
+    if (cat) {
+      renderCategorySection(cat);
+    }
+  }
+
+  function renderCategorySection(cat) {
+    const catEl = catTpl.content.cloneNode(true);
+    catEl.querySelector('.category-title').textContent = cat.name;
+    const postsCont = catEl.querySelector('.category-posts');
+    cat.posts.forEach((post) => {
+      const postEl = createPostElement(post);
+      postsCont.appendChild(postEl);
+    });
+    container.appendChild(catEl);
+  }
+
+  function createPostElement(post) {
+    const postEl = postTpl.content.cloneNode(true);
+    postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+    const titleEl = postEl.querySelector('.post-title');
+    titleEl.textContent = post.title;
+    titleEl.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.location.href = `/post-guest?id=${post.id}`;
+    });
+    postEl.querySelector('.post-content').textContent = post.content;
+    postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();
+    const likes = (post.reactions || []).filter((r) => r.reaction_type === 1).length;
+    const dislikes = (post.reactions || []).filter((r) => r.reaction_type === 2).length;
+    postEl.querySelector('.like-count').textContent = likes;
+    postEl.querySelector('.dislike-count').textContent = dislikes;
+    const commentsCont = postEl.querySelector('.post-comments');
+    for (const comment of post.comments || []) {
+      const cEl = commentTpl.content.cloneNode(true);
+      cEl.querySelector('.comment-user').textContent = comment.username;
+      cEl.querySelector('.comment-content').textContent = comment.content;
+      cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
+      const clikes = (comment.reactions || []).filter((r) => r.reaction_type === 1).length;
+      const cdislikes = (comment.reactions || []).filter((r) => r.reaction_type === 2).length;
+      cEl.querySelector('.like-count').textContent = clikes;
+      cEl.querySelector('.dislike-count').textContent = cdislikes;
+      commentsCont.appendChild(cEl);
+    }
+    return postEl;
   }
 });

--- a/ui/static/js/post_guest.js
+++ b/ui/static/js/post_guest.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('forumContainer');
+  const postTpl = document.getElementById('post-template');
+  const commentTpl = document.getElementById('comment-template');
+
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+  if (!id) {
+    container.textContent = 'Post not found';
+    return;
+  }
+
+  try {
+    const res = await fetch(`http://localhost:8080/forum/api/posts/${id}`);
+    if (!res.ok) throw new Error('load error');
+    const data = await res.json();
+    renderPost(data);
+  } catch (err) {
+    container.textContent = 'Error loading post';
+  }
+
+  function renderPost(post) {
+    container.innerHTML = '';
+    const postEl = postTpl.content.cloneNode(true);
+    postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+    postEl.querySelector('.post-title').textContent = post.title;
+    postEl.querySelector('.post-content').textContent = post.content;
+    postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();
+    const likes = (post.reactions || []).filter(r => r.reaction_type === 1).length;
+    const dislikes = (post.reactions || []).filter(r => r.reaction_type === 2).length;
+    postEl.querySelector('.like-count').textContent = likes;
+    postEl.querySelector('.dislike-count').textContent = dislikes;
+    const commentsCont = postEl.querySelector('.post-comments');
+    for (const comment of post.comments || []) {
+      const cEl = commentTpl.content.cloneNode(true);
+      cEl.querySelector('.comment-user').textContent = comment.username;
+      cEl.querySelector('.comment-content').textContent = comment.content;
+      cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
+      const clikes = (comment.reactions || []).filter(r => r.reaction_type === 1).length;
+      const cdislikes = (comment.reactions || []).filter(r => r.reaction_type === 2).length;
+      cEl.querySelector('.like-count').textContent = clikes;
+      cEl.querySelector('.dislike-count').textContent = cdislikes;
+      commentsCont.appendChild(cEl);
+    }
+    container.appendChild(postEl);
+  }
+});

--- a/ui/static/templates/guest.html
+++ b/ui/static/templates/guest.html
@@ -38,7 +38,7 @@
     <template id="post-template">
       <div class="post">
         <h3 class="post-header"></h3>
-        <div class="post-title"></div>
+        <a class="post-title" href="#"></a>
         <p class="post-content"></p>
         <time class="post-time"></time>
         <div class="post-reactions">

--- a/ui/static/templates/post_guest.html
+++ b/ui/static/templates/post_guest.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>View Post</title>
+    <link rel="stylesheet" href="/static/css/guest.css" />
+  </head>
+  <body>
+    <nav class="navbar">
+      <a class="navbar-brand" href="/guest">Forum</a>
+    </nav>
+
+    <div class="forum-content" id="forumContainer"></div>
+
+    <template id="post-template">
+      <div class="post">
+        <h3 class="post-header"></h3>
+        <div class="post-title"></div>
+        <p class="post-content"></p>
+        <time class="post-time"></time>
+        <div class="post-reactions">
+          <button class="like-btn" disabled>▲ <span class="like-count">0</span></button>
+          <button class="dislike-btn" disabled>▼ <span class="dislike-count">0</span></button>
+        </div>
+        <div class="post-comments"></div>
+      </div>
+    </template>
+
+    <template id="comment-template">
+      <div class="comment">
+        <strong class="comment-user"></strong>
+        <span class="comment-content"></span>
+        <time class="comment-time"></time>
+        <div class="comment-reactions">
+          <button class="like-btn" disabled>▲ <span class="like-count">0</span></button>
+          <button class="dislike-btn" disabled>▼ <span class="dislike-count">0</span></button>
+        </div>
+      </div>
+    </template>
+    <script type="module" src="/static/js/post_guest.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add post-guest route in UI server
- allow guest page to filter posts by category
- make post titles link to the single post page
- create guest post page with JS logic to load post

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `(cd API && go test ./...)` *(fails due to blocked network access)*
- `(cd ui && go test ./...)` *(fails due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_68551ed5c0388324b54d651bff6ddc94