### PR TITLE
Remove comment list from feed views

### DIFF
--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
   const catTpl = document.getElementById('category-template');
   const postTpl = document.getElementById('post-template');
-  const commentTpl = document.getElementById('comment-template');
   const tabs = document.getElementById('category-tabs');
   const feedLink = document.getElementById('my-feed-link');
   let allData;
@@ -79,18 +78,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const dislikes = (post.reactions || []).filter((r) => r.reaction_type === 2).length;
     postEl.querySelector('.like-count').textContent = likes;
     postEl.querySelector('.dislike-count').textContent = dislikes;
-    const commentsCont = postEl.querySelector('.post-comments');
-    for (const comment of post.comments || []) {
-      const cEl = commentTpl.content.cloneNode(true);
-      cEl.querySelector('.comment-user').textContent = comment.username;
-      cEl.querySelector('.comment-content').textContent = comment.content;
-      cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
-      const clikes = (comment.reactions || []).filter((r) => r.reaction_type === 1).length;
-      const cdislikes = (comment.reactions || []).filter((r) => r.reaction_type === 2).length;
-      cEl.querySelector('.like-count').textContent = clikes;
-      cEl.querySelector('.dislike-count').textContent = cdislikes;
-      commentsCont.appendChild(cEl);
-    }
     return postEl;
   }
 });

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
   const catTpl = document.getElementById('category-template');
   const postTpl = document.getElementById('post-template');
-  const commentTpl = document.getElementById('comment-template');
   const csrfToken = sessionStorage.getItem('csrf_token');
   async function verify() {
     const res = await fetch('http://localhost:8080/forum/api/session/verify', {credentials:'include'});
@@ -55,14 +54,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         dislikeBtn.querySelector('.dislike-count').textContent = dislikes;
         likeBtn.addEventListener('click', () => react(post.id, 'post', 1));
         dislikeBtn.addEventListener('click', () => react(post.id, 'post', 2));
-        const commentsCont = postEl.querySelector('.post-comments');
-        for (const comment of post.comments || []) {
-          const cEl = commentTpl.content.cloneNode(true);
-          cEl.querySelector('.comment-user').textContent = comment.username;
-          cEl.querySelector('.comment-content').textContent = comment.content;
-          cEl.querySelector('.comment-time').textContent = new Date(comment.created_at).toLocaleString();
-          commentsCont.appendChild(cEl);
-        }
         const commentBtn = postEl.querySelector('.comment-btn');
         commentBtn.addEventListener('click', async () => {
           const text = prompt('Comment:');

--- a/ui/static/templates/guest.html
+++ b/ui/static/templates/guest.html
@@ -49,23 +49,6 @@
             ▼  <span class="dislike-count">0</span>
           </button>
         </div>
-        <div class="post-comments"></div>
-      </div>
-    </template>
-
-    <template id="comment-template">
-      <div class="comment">
-        <strong class="comment-user"></strong>
-        <span class="comment-content"></span>
-        <time class="comment-time"></time>
-        <div class="comment-reactions">
-          <button class="like-btn" disabled>
-            ▲  <span class="like-count">0</span>
-          </button>
-          <button class="dislike-btn" disabled>
-            ▼  <span class="dislike-count">0</span>
-          </button>
-        </div>
       </div>
     </template>
     <script type="module" src="/static/js/guest.js"></script>

--- a/ui/static/templates/user.html
+++ b/ui/static/templates/user.html
@@ -49,19 +49,6 @@
           <button class="dislike-btn">▼  <span class="dislike-count">0</span></button>
           <button class="comment-btn">Add Comment</button>
         </div>
-        <div class="post-comments"></div>
-      </div>
-    </template>
-
-    <template id="comment-template">
-      <div class="comment">
-        <strong class="comment-user"></strong>
-        <span class="comment-content"></span>
-        <time class="comment-time"></time>
-        <div class="comment-reactions">
-          <button class="like-btn">▲ <span class="like-count">0</span></button>
-          <button class="dislike-btn">▼ <span class="dislike-count">0</span></button>
-        </div>
       </div>
     </template>
 


### PR DESCRIPTION
## Summary
- hide guest and user comment lists in feed pages
- keep comment display for single post views only

## Testing
- `go vet ./...` *(fails: fetching toolchain from storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685528f77a58832493909a501dfde799