### PR TITLE
Implement category posts endpoint

### DIFF
--- a/API/handlers/category_handler.go
+++ b/API/handlers/category_handler.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 
 	"forum/repository"
 	"forum/utils"
@@ -10,11 +12,19 @@ import (
 // CategoryHandler handles category related requests
 type CategoryHandler struct {
 	CategoryRepo *repository.CategoryRepository
+	PostRepo     *repository.PostRepository
+	CommentRepo  *repository.CommentRepository
+	ReactionRepo *repository.ReactionRepository
 }
 
 // NewCategoryHandler creates a new CategoryHandler
-func NewCategoryHandler(repo *repository.CategoryRepository) *CategoryHandler {
-	return &CategoryHandler{CategoryRepo: repo}
+func NewCategoryHandler(catRepo *repository.CategoryRepository, postRepo *repository.PostRepository, commentRepo *repository.CommentRepository, reactionRepo *repository.ReactionRepository) *CategoryHandler {
+	return &CategoryHandler{
+		CategoryRepo: catRepo,
+		PostRepo:     postRepo,
+		CommentRepo:  commentRepo,
+		ReactionRepo: reactionRepo,
+	}
 }
 
 // GetCategories returns all categories as JSON
@@ -31,4 +41,106 @@ func (h *CategoryHandler) GetCategories(w http.ResponseWriter, r *http.Request) 
 	}
 
 	utils.JSONResponse(w, categories, http.StatusOK)
+}
+
+// GetPostsByCategory returns all posts for a specific category along with
+// related comments and reactions. The category ID is extracted from the URL
+// path: /forum/api/categories/{id}/posts
+func (h *CategoryHandler) GetPostsByCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/forum/api/categories/")
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 || parts[1] != "posts" {
+		utils.ErrorResponse(w, "Category ID required", http.StatusBadRequest)
+		return
+	}
+
+	catID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		utils.ErrorResponse(w, "Invalid category ID", http.StatusBadRequest)
+		return
+	}
+
+	posts, err := h.PostRepo.GetPostsByCategoryWithUser(catID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load posts", http.StatusInternalServerError)
+		return
+	}
+
+	var response []MyPostResponse
+	for _, post := range posts {
+		categories, err := h.PostRepo.GetCategoriesByPostID(post.ID)
+		if err != nil {
+			utils.ErrorResponse(w, "Failed to load categories", http.StatusInternalServerError)
+			return
+		}
+		var catInfo []CategoryInfo
+		for _, c := range categories {
+			catInfo = append(catInfo, CategoryInfo{ID: c.ID, Name: c.Name})
+		}
+
+		comments, err := h.CommentRepo.GetCommentsByPostWithUser(post.ID)
+		if err != nil {
+			utils.ErrorResponse(w, "Failed to load comments", http.StatusInternalServerError)
+			return
+		}
+		var commentResp []CommentResponse
+		for _, c := range comments {
+			cr := CommentResponse{
+				ID:        c.ID,
+				UserID:    c.UserID,
+				Username:  c.Username,
+				Content:   c.Content,
+				CreatedAt: c.CreatedAt,
+				Reactions: []ReactionResponse{},
+			}
+			reactions, err := h.ReactionRepo.GetReactionsByCommentWithUser(c.ID)
+			if err != nil {
+				utils.ErrorResponse(w, "Failed to load reactions", http.StatusInternalServerError)
+				return
+			}
+			for _, r := range reactions {
+				cr.Reactions = append(cr.Reactions, ReactionResponse{
+					UserID:       r.UserID,
+					Username:     r.Username,
+					ReactionType: r.ReactionType,
+					CreatedAt:    r.CreatedAt,
+				})
+			}
+			commentResp = append(commentResp, cr)
+		}
+
+		reactions, err := h.ReactionRepo.GetReactionsByPostWithUser(post.ID)
+		if err != nil {
+			utils.ErrorResponse(w, "Failed to load reactions", http.StatusInternalServerError)
+			return
+		}
+		var reactResp []ReactionResponse
+		for _, r := range reactions {
+			reactResp = append(reactResp, ReactionResponse{
+				UserID:       r.UserID,
+				Username:     r.Username,
+				ReactionType: r.ReactionType,
+				CreatedAt:    r.CreatedAt,
+			})
+		}
+
+		response = append(response, MyPostResponse{
+			ID:         post.ID,
+			UserID:     post.UserID,
+			Username:   post.Username,
+			Categories: catInfo,
+			Title:      post.Title,
+			Content:    post.Content,
+			CreatedAt:  post.CreatedAt,
+			Comments:   commentResp,
+			Reactions:  reactResp,
+		})
+	}
+
+	utils.JSONResponse(w, response, http.StatusOK)
 }

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -21,7 +21,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 
 	// Create handlers
 	authHandler := handlers.NewAuthHandler(userRepo, sessionRepo)
-	categoryHandler := handlers.NewCategoryHandler(categoryRepo)
+	categoryHandler := handlers.NewCategoryHandler(categoryRepo, postRepo, commentRepo, reactionRepo)
 	postHandler := handlers.NewPostHandler(postRepo, commentRepo, reactionRepo)
 	myPostsHandler := handlers.NewMyPostsHandler(postRepo, commentRepo, reactionRepo)
 	likedPostsHandler := handlers.NewLikedPostsHandler(postRepo, commentRepo, reactionRepo)
@@ -41,6 +41,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 
 	// Public routes
 	mux.Handle("/forum/api/categories", corsMiddleware.Handler(http.HandlerFunc(categoryHandler.GetCategories)))
+	mux.Handle("/forum/api/categories/", corsMiddleware.Handler(http.HandlerFunc(categoryHandler.GetPostsByCategory)))
 	mux.Handle("/forum/api/allData", corsMiddleware.Handler(http.HandlerFunc(guestHandler.GetGuestData)))
 	mux.Handle("/forum/api/posts/", corsMiddleware.Handler(http.HandlerFunc(postHandler.GetPost)))
 	mux.Handle("/forum/api/register", corsMiddleware.Handler(http.HandlerFunc(registerLimiter.Limit(authHandler.Register))))

--- a/instructions.md
+++ b/instructions.md
@@ -6,6 +6,9 @@ curl  http://localhost:8080/forum/api/guest
 ## Get categories
 curl http://localhost:8080/forum/api/categories
 
+## Get posts in a category
+curl http://localhost:8080/forum/api/categories/1/posts
+
 ## Register a new user:
 
 curl -X POST http://localhost:8080/forum/api/register \


### PR DESCRIPTION
## Summary
- expand `CategoryHandler` with post/comment/reaction repositories
- add `/forum/api/categories/{id}/posts` endpoint
- wire new handler in router
- document how to fetch posts for a category

## Testing
- `gofmt -w API/handlers/category_handler.go API/routes/routes.go`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68552f8dc0108324904c2d0f71233e60