### PR TITLE
Show categories for each post

### DIFF
--- a/ui/static/css/guest.css
+++ b/ui/static/css/guest.css
@@ -233,6 +233,21 @@
     margin: 0 0 0.5em;
     font-size: 1.2em;
   }
+
+  .post-categories {
+    margin-bottom: 0.5em;
+  }
+
+  .post-categories a {
+    color: var(--color-tertiary);
+    margin-right: 0.5em;
+    text-decoration: none;
+    font-size: 0.9em;
+  }
+
+  .post-categories a:hover {
+    text-decoration: underline;
+  }
   
   .post p {
     color: var(--text-secondary);

--- a/ui/static/css/user.css
+++ b/ui/static/css/user.css
@@ -355,6 +355,21 @@ body {
     font-weight: 600;
 }
 
+.post-categories {
+    margin-bottom: 0.5em;
+}
+
+.post-categories a {
+    color: var(--color-tertiary);
+    margin-right: 0.5em;
+    text-decoration: none;
+    font-size: 0.9em;
+}
+
+.post-categories a:hover {
+    text-decoration: underline;
+}
+
 .post p {
     color: var(--text-secondary);
     margin: 0.4em 0;

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const tabs = document.getElementById('category-tabs');
   const feedLink = document.getElementById('my-feed-link');
   let allData;
+  const params = new URLSearchParams(window.location.search);
+  const initialCat = parseInt(params.get('cat'), 10);
 
   feedLink.addEventListener('click', (e) => {
     e.preventDefault();
@@ -16,7 +18,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!res.ok) throw new Error('failed to load');
     allData = await res.json();
     populateCategories();
-    renderFeed();
+    if (initialCat) {
+      renderCategory(initialCat);
+    } else {
+      renderFeed();
+    }
   } catch (err) {
     container.textContent = 'Error loading posts';
   }
@@ -66,6 +72,20 @@ document.addEventListener('DOMContentLoaded', async () => {
   function createPostElement(post) {
     const postEl = postTpl.content.cloneNode(true);
     postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+    const catContainer = postEl.querySelector('.post-categories');
+    if (catContainer && post.categories) {
+      post.categories.forEach(c => {
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = `#${c.name}`;
+        link.dataset.catId = c.id;
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          renderCategory(c.id);
+        });
+        catContainer.appendChild(link);
+      });
+    }
     const titleEl = postEl.querySelector('.post-title');
     titleEl.textContent = post.title;
     titleEl.addEventListener('click', (e) => {

--- a/ui/static/js/post.js
+++ b/ui/static/js/post.js
@@ -50,6 +50,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     container.innerHTML = '';
     const postEl = postTpl.content.cloneNode(true);
     postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+    const catContainer = postEl.querySelector('.post-categories');
+    if (catContainer && post.categories) {
+      post.categories.forEach(c => {
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = `#${c.name}`;
+        link.dataset.catId = c.id;
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          window.location.href = `/user?cat=${c.id}`;
+        });
+        catContainer.appendChild(link);
+      });
+    }
     postEl.querySelector('.post-title').textContent = post.title;
     postEl.querySelector('.post-content').textContent = post.content;
     postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();

--- a/ui/static/js/post_guest.js
+++ b/ui/static/js/post_guest.js
@@ -23,6 +23,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     container.innerHTML = '';
     const postEl = postTpl.content.cloneNode(true);
     postEl.querySelector('.post-header').textContent = `${post.username} posted`;
+    const catContainer = postEl.querySelector('.post-categories');
+    if (catContainer && post.categories) {
+      post.categories.forEach(c => {
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = `#${c.name}`;
+        link.dataset.catId = c.id;
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          window.location.href = `/guest?cat=${c.id}`;
+        });
+        catContainer.appendChild(link);
+      });
+    }
     postEl.querySelector('.post-title').textContent = post.title;
     postEl.querySelector('.post-content').textContent = post.content;
     postEl.querySelector('.post-time').textContent = new Date(post.created_at).toLocaleString();

--- a/ui/static/templates/guest.html
+++ b/ui/static/templates/guest.html
@@ -38,6 +38,7 @@
     <template id="post-template">
       <div class="post">
         <h3 class="post-header"></h3>
+        <div class="post-categories"></div>
         <a class="post-title" href="#"></a>
         <p class="post-content"></p>
         <time class="post-time"></time>

--- a/ui/static/templates/post.html
+++ b/ui/static/templates/post.html
@@ -19,6 +19,7 @@
     <template id="post-template">
       <div class="post">
         <h3 class="post-header"></h3>
+        <div class="post-categories"></div>
         <div class="post-title"></div>
         <p class="post-content"></p>
         <time class="post-time"></time>

--- a/ui/static/templates/post_guest.html
+++ b/ui/static/templates/post_guest.html
@@ -16,6 +16,7 @@
     <template id="post-template">
       <div class="post">
         <h3 class="post-header"></h3>
+        <div class="post-categories"></div>
         <div class="post-title"></div>
         <p class="post-content"></p>
         <time class="post-time"></time>

--- a/ui/static/templates/user.html
+++ b/ui/static/templates/user.html
@@ -41,6 +41,7 @@
     <template id="post-template">
       <div class="post">
         <h3 class="post-header"></h3>
+        <div class="post-categories"></div>
         <a class="post-title" href="#"></a>
         <p class="post-content"></p>
         <time class="post-time"></time>


### PR DESCRIPTION
## Summary
- expand guest handler to include all categories on posts
- show categories on feed and single post templates
- render clickable category tags across guest and user pages
- support `?cat=` query parameter in feeds

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685536c6f11c832486a33dbaffd9c3bb