### PR TITLE
Improve feed ordering

### DIFF
--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -49,7 +49,24 @@ document.addEventListener('DOMContentLoaded', async () => {
   function renderFeed() {
     currentCatId = null;
     container.innerHTML = '';
-    allData.categories.forEach(cat => renderCategorySection(cat, null));
+    const postsMap = new Map();
+    allData.categories.forEach(cat => {
+      cat.posts.forEach(post => {
+        if (!postsMap.has(post.id)) {
+          postsMap.set(post.id, post);
+        }
+      });
+    });
+    const posts = Array.from(postsMap.values()).sort((a, b) =>
+      new Date(b.created_at) - new Date(a.created_at)
+    );
+    const catEl = catTpl.content.cloneNode(true);
+    catEl.querySelector('.category-title').textContent = 'Feed';
+    const postsCont = catEl.querySelector('.category-posts');
+    posts.forEach(post => {
+      postsCont.appendChild(createPostElement(post, null));
+    });
+    container.appendChild(catEl);
   }
 
   function renderCategory(id) {


### PR DESCRIPTION
## Summary
- dedupe posts across categories
- sort feed posts by creation time
- show all posts in a single feed section

## Testing
- `go test ./...` *(fails: Forbidden access to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6855417c3a38832490ed21e6d605e390