### PR TITLE
Add fetchJSON utility and refactor JS fetch calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ message using the `message` query parameter:
 ```bash
 curl "http://localhost:8080/forum/api/error?code=400&message=bad+data"
 ```
+
+## JavaScript Helper
+
+The UI scripts share a `fetchJSON` helper located at
+`ui/static/js/api.js`. Import this function instead of calling
+`fetch` directly:
+
+```javascript
+import { fetchJSON } from './api.js';
+
+const data = await fetchJSON('http://localhost:8080/forum/api/allData', {
+  credentials: 'include'
+});
+```
+
+On success it returns the parsed JSON. When the response is not OK the
+function attempts to parse an error object with `code` and `message`
+and redirects the user to `/error?code=CODE&message=MESSAGE`.

--- a/ui/static/js/api.js
+++ b/ui/static/js/api.js
@@ -1,0 +1,16 @@
+export async function fetchJSON(url, options = {}) {
+  const res = await fetch(url, options);
+  if (res.ok) {
+    return res.json();
+  }
+  let data = {};
+  try {
+    data = await res.json();
+  } catch (_) {
+    // ignore parse error
+  }
+  const code = data.code || res.status;
+  const message = data.message || res.statusText;
+  window.location.href = '/error?code=' + code + '&message=' + encodeURIComponent(message);
+  return null;
+}

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -1,3 +1,5 @@
+import { fetchJSON } from './api.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
   const catTpl = document.getElementById('category-template');
@@ -14,18 +16,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     renderFeed();
   });
 
-  try {
-    const res = await fetch('http://localhost:8080/forum/api/allData');
-    if (!res.ok) throw new Error('failed to load');
-    allData = await res.json();
-    populateCategories();
-    if (initialCat) {
-      renderCategory(initialCat);
-    } else {
-      renderFeed();
-    }
-  } catch (err) {
-    container.textContent = 'Error loading posts';
+  const data = await fetchJSON('http://localhost:8080/forum/api/allData');
+  if (!data) return;
+  allData = data;
+  populateCategories();
+  if (initialCat) {
+    renderCategory(initialCat);
+  } else {
+    renderFeed();
   }
 
   function populateCategories() {

--- a/ui/static/js/login.js
+++ b/ui/static/js/login.js
@@ -1,23 +1,20 @@
+import { fetchJSON } from './api.js';
+
 document.getElementById('loginForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const email = document.getElementById('email').value.trim();
   const password = document.getElementById('password').value.trim();
   const message = document.getElementById('message');
   message.textContent = '';
-  try {
-    const res = await fetch('http://localhost:8080/forum/api/session/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ email, password })
-    });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok) throw new Error(data.message || 'Login failed');
-    if (data.csrf_token) {
-      sessionStorage.setItem('csrf_token', data.csrf_token);
-    }
-    window.location.href = '/user';
-  } catch (err) {
-    message.textContent = err.message;
+  const data = await fetchJSON('http://localhost:8080/forum/api/session/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ email, password })
+  });
+  if (!data) return;
+  if (data.csrf_token) {
+    sessionStorage.setItem('csrf_token', data.csrf_token);
   }
+  window.location.href = '/user';
 });

--- a/ui/static/js/post.js
+++ b/ui/static/js/post.js
@@ -1,4 +1,5 @@
 // Post page for authenticated users
+import { fetchJSON } from './api.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
@@ -7,8 +8,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const csrfToken = sessionStorage.getItem('csrf_token');
 
   async function verify() {
-    const res = await fetch('http://localhost:8080/forum/api/session/verify', { credentials: 'include' });
-    return res.ok;
+    const data = await fetchJSON('http://localhost:8080/forum/api/session/verify', { credentials: 'include' });
+    return !!data;
   }
 
   if (!(await verify())) {
@@ -20,7 +21,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (logoutLink) {
     logoutLink.addEventListener('click', async (e) => {
       e.preventDefault();
-      await fetch('http://localhost:8080/forum/api/session/logout', {
+      await fetchJSON('http://localhost:8080/forum/api/session/logout', {
         method: 'POST',
         credentials: 'include',
         headers: { 'X-CSRF-Token': csrfToken }
@@ -37,12 +38,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function loadPost() {
-    const res = await fetch(`http://localhost:8080/forum/api/posts/${id}`, { credentials: 'include' });
-    if (!res.ok) {
+    const data = await fetchJSON(`http://localhost:8080/forum/api/posts/${id}`, { credentials: 'include' });
+    if (!data) {
       container.textContent = 'Error loading post';
       return;
     }
-    const data = await res.json();
     renderPost(data);
   }
 
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function react(targetId, type, rtype) {
-    await fetch('http://localhost:8080/forum/api/react', {
+    await fetchJSON('http://localhost:8080/forum/api/react', {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function createComment(postId, content) {
-    await fetch('http://localhost:8080/forum/api/comments', {
+    await fetchJSON('http://localhost:8080/forum/api/comments', {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/ui/static/js/post_guest.js
+++ b/ui/static/js/post_guest.js
@@ -1,3 +1,5 @@
+import { fetchJSON } from './api.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
   const postTpl = document.getElementById('post-template');
@@ -10,14 +12,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     return;
   }
 
-  try {
-    const res = await fetch(`http://localhost:8080/forum/api/posts/${id}`);
-    if (!res.ok) throw new Error('load error');
-    const data = await res.json();
-    renderPost(data);
-  } catch (err) {
+  const data = await fetchJSON(`http://localhost:8080/forum/api/posts/${id}`);
+  if (!data) {
     container.textContent = 'Error loading post';
+    return;
   }
+  renderPost(data);
 
   function renderPost(post) {
     container.innerHTML = '';

--- a/ui/static/js/register.js
+++ b/ui/static/js/register.js
@@ -1,3 +1,5 @@
+import { fetchJSON } from './api.js';
+
 // Handle registration form submission via fetch
 document.getElementById('registerForm').addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -11,16 +13,11 @@ document.getElementById('registerForm').addEventListener('submit', async (e) => 
     message.textContent = 'Passwords do not match';
     return;
   }
-  try {
-    const res = await fetch('http://localhost:8080/forum/api/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, email, password })
-    });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok) throw new Error(data.message || 'Registration failed');
-    window.location.href = '/login';
-  } catch (err) {
-    message.textContent = err.message;
-  }
+  const data = await fetchJSON('http://localhost:8080/forum/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, email, password })
+  });
+  if (!data) return;
+  window.location.href = '/login';
 });

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -1,3 +1,5 @@
+import { fetchJSON } from './api.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
   const catTpl = document.getElementById('category-template');
@@ -10,8 +12,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const initialCat = parseInt(params.get('cat'), 10);
   let currentCatId = initialCat || null;
   async function verify() {
-    const res = await fetch('http://localhost:8080/forum/api/session/verify', {credentials:'include'});
-    return res.ok;
+    const data = await fetchJSON('http://localhost:8080/forum/api/session/verify', { credentials: 'include' });
+    return !!data;
   }
   if (!(await verify())) {
     window.location.href = '/login';
@@ -21,7 +23,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (logoutLink) {
     logoutLink.addEventListener('click', async (e) => {
       e.preventDefault();
-      await fetch('http://localhost:8080/forum/api/session/logout', {
+      await fetchJSON('http://localhost:8080/forum/api/session/logout', {
         method: 'POST',
         credentials: 'include',
         headers: { 'X-CSRF-Token': csrfToken }
@@ -37,9 +39,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function loadData() {
-    const res = await fetch('http://localhost:8080/forum/api/allData', {credentials:'include'});
-    if (!res.ok) throw new Error('load error');
-    allData = await res.json();
+    const data = await fetchJSON('http://localhost:8080/forum/api/allData', { credentials: 'include' });
+    if (!data) return;
+    allData = data;
     populateCategories();
     if (currentCatId) {
       renderCategory(currentCatId);
@@ -154,7 +156,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
   async function react(id, type, rtype) {
-    await fetch('http://localhost:8080/forum/api/react', {
+    await fetchJSON('http://localhost:8080/forum/api/react', {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -166,7 +168,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     loadData();
   }
   async function createComment(postId, content) {
-    await fetch('http://localhost:8080/forum/api/comments', {
+    await fetchJSON('http://localhost:8080/forum/api/comments', {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -190,9 +192,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     submitBtn.addEventListener('click', createPost);
   }
   async function loadCategories() {
-    const res = await fetch('http://localhost:8080/forum/api/categories');
-    if (!res.ok) return;
-    const cats = await res.json();
+    const cats = await fetchJSON('http://localhost:8080/forum/api/categories');
+    if (!cats) return;
     const cont = document.getElementById('post-category');
     cont.innerHTML = '';
     cats.forEach(c => {
@@ -214,7 +215,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const catChecks = document.querySelectorAll('#post-category input:checked');
     const ids = Array.from(catChecks).map(c => parseInt(c.value,10));
     if (!title || !content || ids.length === 0) return;
-    await fetch('http://localhost:8080/forum/api/posts/create', {
+    await fetchJSON('http://localhost:8080/forum/api/posts/create', {
       method: 'POST',
       credentials: 'include',
       headers: {


### PR DESCRIPTION
## Summary
- add `ui/static/js/api.js` with `fetchJSON` helper
- update UI scripts to use the new helper
- document helper usage in README

## Testing
- `go test ./...` *(fails: network access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_6855469fd66c8324960bf77e902e2305