### PR TITLE
Fix logout token restoration

### DIFF
--- a/API/handlers/auth_handlers.go
+++ b/API/handlers/auth_handlers.go
@@ -234,12 +234,19 @@ func (h *AuthHandler) VerifySession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Optionally fetch user and return profile
+	// Fetch user profile
 	user, err := h.UserRepo.GetByID(session.UserID)
 	if err != nil {
 		http.Error(w, "User not found", http.StatusInternalServerError)
 		return
 	}
 
-	utils.JSONResponse(w, user, http.StatusOK)
+	// Include CSRF token so the frontend can restore it after a refresh
+	resp := models.LoginResponse{
+		User:      *user,
+		SessionID: session.SessionID,
+		CSRFToken: session.CSRFToken,
+	}
+
+	utils.JSONResponse(w, resp, http.StatusOK)
 }

--- a/ui/static/js/post.js
+++ b/ui/static/js/post.js
@@ -5,10 +5,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('forumContainer');
   const postTpl = document.getElementById('post-template');
   const commentTpl = document.getElementById('comment-template');
-  const csrfToken = sessionStorage.getItem('csrf_token');
+  let csrfToken = sessionStorage.getItem('csrf_token');
 
   async function verify() {
     const data = await fetchJSON('http://localhost:8080/forum/api/session/verify', { credentials: 'include' });
+    if (data && data.csrf_token) {
+      sessionStorage.setItem('csrf_token', data.csrf_token);
+      csrfToken = data.csrf_token;
+    }
     return !!data;
   }
 

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -6,13 +6,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   const postTpl = document.getElementById('post-template');
   const tabs = document.getElementById('category-tabs');
   const feedLink = document.getElementById('my-feed-link');
-  const csrfToken = sessionStorage.getItem('csrf_token');
+  let csrfToken = sessionStorage.getItem('csrf_token');
   let allData;
   const params = new URLSearchParams(window.location.search);
   const initialCat = parseInt(params.get('cat'), 10);
   let currentCatId = initialCat || null;
   async function verify() {
     const data = await fetchJSON('http://localhost:8080/forum/api/session/verify', { credentials: 'include' });
+    if (data && data.csrf_token) {
+      sessionStorage.setItem('csrf_token', data.csrf_token);
+      csrfToken = data.csrf_token;
+    }
     return !!data;
   }
   if (!(await verify())) {


### PR DESCRIPTION
## Summary
- return CSRF token from `/session/verify`
- save CSRF token after verification in frontend scripts

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68554f33d2f083248620239b60bfcee2