### PR TITLE
Handle missing categories

### DIFF
--- a/API/handlers/category_handler.go
+++ b/API/handlers/category_handler.go
@@ -65,6 +65,15 @@ func (h *CategoryHandler) GetPostsByCategory(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if _, err := h.CategoryRepo.GetByID(catID); err != nil {
+		if err == repository.ErrCategoryNotFound {
+			utils.ErrorResponse(w, "Category not found", http.StatusNotFound)
+			return
+		}
+		utils.ErrorResponse(w, "Failed to load category", http.StatusInternalServerError)
+		return
+	}
+
 	posts, err := h.PostRepo.GetPostsByCategoryWithUser(catID)
 	if err != nil {
 		utils.ErrorResponse(w, "Failed to load posts", http.StatusInternalServerError)

--- a/API/repository/category_repository.go
+++ b/API/repository/category_repository.go
@@ -3,8 +3,11 @@ package repository
 
 import (
 	"database/sql"
+	"errors"
 	"forum/models"
 )
+
+var ErrCategoryNotFound = errors.New("category not found")
 
 type CategoryRepository struct {
 	db *sql.DB
@@ -30,6 +33,19 @@ func (r *CategoryRepository) GetAll() ([]models.Category, error) {
 		categories = append(categories, cat)
 	}
 	return categories, nil
+}
+
+func (r *CategoryRepository) GetByID(id int) (*models.Category, error) {
+	var cat models.Category
+	err := r.db.QueryRow("SELECT category_id, name FROM categories WHERE category_id = ?", id).
+		Scan(&cat.ID, &cat.Name)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrCategoryNotFound
+		}
+		return nil, err
+	}
+	return &cat, nil
 }
 
 // repository/post_repository.go

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -70,10 +70,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   function renderCategory(id) {
     container.innerHTML = '';
     const cat = allData.categories.find((c) => c.id === id);
-    if (cat) {
-      currentCatId = id;
-      renderCategorySection(cat);
+    if (!cat) {
+      window.location.href = '/error?code=404&message=Category%20not%20found';
+      return;
     }
+    currentCatId = id;
+    renderCategorySection(cat);
   }
 
   function renderCategorySection(cat) {

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -144,11 +144,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   function renderCategory(id) {
     if (!allData) return;
     const cat = allData.categories.find(c => c.id === id);
-    if (cat) {
-      currentCatId = id;
-      container.innerHTML = '';
-      renderCategorySection(cat);
+    if (!cat) {
+      window.location.href = '/error?code=404&message=Category%20not%20found';
+      return;
     }
+    currentCatId = id;
+    container.innerHTML = '';
+    renderCategorySection(cat);
   }
   async function react(id, type, rtype) {
     await fetchJSON('http://localhost:8080/forum/api/react', {


### PR DESCRIPTION
## Summary
- validate category ID with `GetByID`
- return 404 when a category doesn't exist
- show category not found error page in guest and user views

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `(cd ui && go vet ./...)` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685553f366188324ab7ecfb81877b072