### PR TITLE
Refresh page after feed or post actions

### DIFF
--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   feedLink.addEventListener('click', (e) => {
     e.preventDefault();
-    renderFeed();
+    window.location.href = '/guest';
   });
 
   const data = await fetchJSON('http://localhost:8080/forum/api/allData');

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (feedLink) {
     feedLink.addEventListener('click', (e) => {
       e.preventDefault();
-      renderFeed();
+      window.location.href = '/user';
     });
   }
 
@@ -222,7 +222,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       body: JSON.stringify({ title, content, category_ids: ids })
     });
     modal.classList.add('hidden');
-    await loadData();
+    window.location.reload();
   }
   loadCategories();
   loadData();


### PR DESCRIPTION
## Summary
- change feed link behavior on user & guest pages to reload
- reload the page after creating a post

## Testing
- `go vet ./...` *(fails: Forbidden while fetching Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68556b4e2a188324a267933cdc109a34