### PR TITLE
Improve session checks in frontend

### DIFF
--- a/ui/static/js/login.js
+++ b/ui/static/js/login.js
@@ -1,5 +1,24 @@
 import { fetchJSON } from './api.js';
 
+async function checkSession() {
+  try {
+    const res = await fetch('http://localhost:8080/forum/api/session/verify', {
+      credentials: 'include'
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.csrf_token) {
+        sessionStorage.setItem('csrf_token', data.csrf_token);
+      }
+      window.location.href = '/user';
+    }
+  } catch (_) {
+    // ignore network errors and stay on the page
+  }
+}
+
+document.addEventListener('DOMContentLoaded', checkSession);
+
 document.getElementById('loginForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const email = document.getElementById('email').value.trim();

--- a/ui/static/js/user.js
+++ b/ui/static/js/user.js
@@ -12,12 +12,22 @@ document.addEventListener('DOMContentLoaded', async () => {
   const initialCat = parseInt(params.get('cat'), 10);
   let currentCatId = initialCat || null;
   async function verify() {
-    const data = await fetchJSON('http://localhost:8080/forum/api/session/verify', { credentials: 'include' });
-    if (data && data.csrf_token) {
-      sessionStorage.setItem('csrf_token', data.csrf_token);
-      csrfToken = data.csrf_token;
+    try {
+      const res = await fetch('http://localhost:8080/forum/api/session/verify', {
+        credentials: 'include'
+      });
+      if (!res.ok) {
+        return false;
+      }
+      const data = await res.json();
+      if (data && data.csrf_token) {
+        sessionStorage.setItem('csrf_token', data.csrf_token);
+        csrfToken = data.csrf_token;
+      }
+      return true;
+    } catch (_) {
+      return false;
     }
-    return !!data;
   }
   if (!(await verify())) {
     window.location.href = '/login';


### PR DESCRIPTION
## Summary
- validate active sessions on the login page
- verify the session without redirecting when loading the dashboard

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855798866b48324ac232d6440f4295a