### PR TITLE
Improve logout handling on /login

### DIFF
--- a/ui/cmd/main.go
+++ b/ui/cmd/main.go
@@ -34,6 +34,9 @@ func main() {
 		http.ServeFile(w, r, "./static/templates/index.html")
 	})
 	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		// Prevent caching the login page so hitting the back button
+		// always triggers a fresh logout.
+		w.Header().Set("Cache-Control", "no-store")
 		http.ServeFile(w, r, "./static/templates/login.html")
 	})
 	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {

--- a/ui/static/js/login.js
+++ b/ui/static/js/login.js
@@ -1,13 +1,24 @@
 import { fetchJSON } from './api.js';
 
-// Automatically terminate any existing session when the login page loads
-// so navigating back to this page will log the user out.
-document.addEventListener('DOMContentLoaded', async () => {
+async function performLogout() {
   await fetchJSON('http://localhost:8080/forum/api/session/logout', {
     method: 'POST',
     credentials: 'include'
   });
   sessionStorage.removeItem('csrf_token');
+}
+
+// Automatically terminate any existing session when the login page loads
+// so navigating back to this page will log the user out.
+document.addEventListener('DOMContentLoaded', performLogout);
+
+// When navigating back to this page from the browser history, some browsers
+// restore the page from the back-forward cache. The pageshow event with
+// `persisted` set lets us detect that situation and ensure the user is logged out.
+window.addEventListener('pageshow', (e) => {
+  if (e.persisted) {
+    performLogout();
+  }
 });
 
 document.getElementById('loginForm').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- logout logic is now in a reusable `performLogout()` function
- run logout on `DOMContentLoaded` and when page is restored from bfc
- set `Cache-Control: no-store` header on `/login`

## Testing
- `go fmt ./...` *(fails: directory prefix does not contain main module)*
- `go build ./...` *(fails to download modules: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68557f55762c8324a9b43c2d96c07ed3